### PR TITLE
feat(publish-helper): update conventional-changelog-angular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12590,16 +12590,6 @@
         }
       ]
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14917,7 +14907,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "conventional-changelog-angular": "^5.0.13",
+        "conventional-changelog-angular": "^8.0.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -14935,15 +14925,14 @@
       }
     },
     "packages/publish-helper/node_modules/conventional-changelog-angular": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "packages/utilities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14904,7 +14904,7 @@
     },
     "packages/publish-helper": {
       "name": "@shiftcode/publish-helper",
-      "version": "3.0.1",
+      "version": "3.1.0-pr32.0",
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/publish-helper",
-  "version": "3.0.1",
+  "version": "3.1.0-pr32.0",
   "description": "scripts for conventional (pre)releases",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -26,7 +26,7 @@
     "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
-    "conventional-changelog-angular": "^5.0.13",
+    "conventional-changelog-angular": "^8.0.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Simply updates the `conventional-changelog-angular` dependency of `publish-helper` to the latest version