### PR TITLE
Add support for @angular-eslint/*@20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14847,7 +14847,7 @@
     },
     "packages/eslint-config-recommended": {
       "name": "@shiftcode/eslint-config-recommended",
-      "version": "5.0.0-pr50.1",
+      "version": "5.0.0-pr50.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@shiftcode/eslint-plugin-rules": "^4.0.0",

--- a/packages/eslint-config-recommended/package.json
+++ b/packages/eslint-config-recommended/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/eslint-config-recommended",
-  "version": "5.0.0-pr50.1",
+  "version": "5.0.0-pr50.2",
   "description": "default shiftcode config for eslint",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "UNLICENSED",


### PR DESCRIPTION
Adds support for `@angular-eslint/*@20`

> ⚠️  BREAKING CHANGE:
minimum version of @angular-eslint/* peer dependencies must be ^20