### PR TITLE
feat(branch-utilities): support naming convention for github copilot branch names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14836,7 +14836,7 @@
     },
     "packages/branch-utilities": {
       "name": "@shiftcode/branch-utilities",
-      "version": "4.0.0",
+      "version": "4.1.0-pr58.0",
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
@@ -14921,7 +14921,7 @@
     },
     "packages/publish-helper": {
       "name": "@shiftcode/publish-helper",
-      "version": "4.0.0",
+      "version": "4.0.1-pr58.0",
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
@@ -14932,7 +14932,7 @@
         "publish-lib": "dist/publish-lib.js"
       },
       "devDependencies": {
-        "@shiftcode/branch-utilities": "^4.0.0",
+        "@shiftcode/branch-utilities": "^4.1.0-pr58.0",
         "@types/yargs": "^17.0.32"
       },
       "engines": {

--- a/packages/branch-utilities/package.json
+++ b/packages/branch-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/branch-utilities",
-  "version": "4.0.0",
+  "version": "4.1.0-pr58.0",
   "description": "Utilities for local and ci to get branch name and stage",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/branch-utilities/src/lib/base.utils.spec.ts
+++ b/packages/branch-utilities/src/lib/base.utils.spec.ts
@@ -81,11 +81,20 @@ describe('base utils', () => {
   })
 
   describe('parseBranchName', () => {
+
     test('works when valid pattern', () => {
-      expect(parseBranchName('#7-abc').branchId).toBe(7)
+      expect(parseBranchName('#7-abc')).toEqual({ branchId: 7, branchName: 'abc' } satisfies ReturnType<typeof parseBranchName>)
+
       expect(parseBranchName('#72-abc').branchId).toBe(72)
+      expect(parseBranchName('#000-int').branchId).toBe(0)
+      expect(parseBranchName('#001-test').branchId).toBe(1)
+
       expect(parseBranchName('#72- whatever').branchId).toBe(72)
       expect(parseBranchName('feature/#72-ok').branchId).toBe(72)
+    })
+
+    test('works for github copilot created branches', () => {
+      expect(parseBranchName('copilot/fix-123')).toEqual({ branchId: 123, branchName: 'fix' } satisfies ReturnType<typeof parseBranchName>)
     })
     test('throws when invalid pattern', () => {
       expect(() => parseBranchName('whrjwe')).toThrow()

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/publish-helper",
-  "version": "4.0.0",
+  "version": "4.0.1-pr58.0",
   "description": "scripts for conventional (pre)releases",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@shiftcode/branch-utilities": "^4.0.0",
+    "@shiftcode/branch-utilities": "^4.1.0-pr58.0",
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {


### PR DESCRIPTION

BREAKING CHANGE
REGEX_BRANCH_NAME is no longer exported. use the utility function `parseBranchName` instead

closes #58 