### PR TITLE
feat(branch-utilities): support naming convention for github copilot …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14836,7 +14836,7 @@
     },
     "packages/branch-utilities": {
       "name": "@shiftcode/branch-utilities",
-      "version": "4.0.0",
+      "version": "5.0.0-pr58.0",
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
@@ -14921,7 +14921,7 @@
     },
     "packages/publish-helper": {
       "name": "@shiftcode/publish-helper",
-      "version": "4.0.0",
+      "version": "4.0.1-pr58.0",
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
@@ -14932,7 +14932,7 @@
         "publish-lib": "dist/publish-lib.js"
       },
       "devDependencies": {
-        "@shiftcode/branch-utilities": "^4.0.0",
+        "@shiftcode/branch-utilities": "^5.0.0-pr58.0",
         "@types/yargs": "^17.0.32"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14836,7 +14836,7 @@
     },
     "packages/branch-utilities": {
       "name": "@shiftcode/branch-utilities",
-      "version": "5.0.0-pr58.0",
+      "version": "5.0.0-pr58.1",
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
@@ -14921,7 +14921,7 @@
     },
     "packages/publish-helper": {
       "name": "@shiftcode/publish-helper",
-      "version": "4.0.1-pr58.0",
+      "version": "4.1.0-pr58.0",
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
@@ -14932,14 +14932,14 @@
         "publish-lib": "dist/publish-lib.js"
       },
       "devDependencies": {
-        "@shiftcode/branch-utilities": "^5.0.0-pr58.0",
+        "@shiftcode/branch-utilities": "^5.0.0-pr58.1",
         "@types/yargs": "^17.0.32"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
       },
       "peerDependencies": {
-        "@shiftcode/branch-utilities": "^4.0.0 || ^4.0.0-pr45",
+        "@shiftcode/branch-utilities": "^4.0.0 || ^5.0.0-pr58.0",
         "lerna": "^8.1.6",
         "tslib": "^2.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14836,7 +14836,7 @@
     },
     "packages/branch-utilities": {
       "name": "@shiftcode/branch-utilities",
-      "version": "5.0.0-pr58.2",
+      "version": "5.0.0-pr58.3",
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
@@ -14921,7 +14921,7 @@
     },
     "packages/publish-helper": {
       "name": "@shiftcode/publish-helper",
-      "version": "4.1.0-pr58.1",
+      "version": "4.1.0-pr58.2",
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
@@ -14932,7 +14932,7 @@
         "publish-lib": "dist/publish-lib.js"
       },
       "devDependencies": {
-        "@shiftcode/branch-utilities": "^5.0.0-pr58.2",
+        "@shiftcode/branch-utilities": "^5.0.0-pr58.3",
         "@types/yargs": "^17.0.32"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14836,7 +14836,7 @@
     },
     "packages/branch-utilities": {
       "name": "@shiftcode/branch-utilities",
-      "version": "5.0.0-pr58.1",
+      "version": "5.0.0-pr58.2",
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
@@ -14921,7 +14921,7 @@
     },
     "packages/publish-helper": {
       "name": "@shiftcode/publish-helper",
-      "version": "4.1.0-pr58.0",
+      "version": "4.1.0-pr58.1",
       "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
@@ -14932,14 +14932,14 @@
         "publish-lib": "dist/publish-lib.js"
       },
       "devDependencies": {
-        "@shiftcode/branch-utilities": "^5.0.0-pr58.1",
+        "@shiftcode/branch-utilities": "^5.0.0-pr58.2",
         "@types/yargs": "^17.0.32"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0"
       },
       "peerDependencies": {
-        "@shiftcode/branch-utilities": "^4.0.0 || ^5.0.0-pr58.0",
+        "@shiftcode/branch-utilities": "^4.0.0 || ^5.0.0-pr58 || ^5.0.0",
         "lerna": "^8.1.6",
         "tslib": "^2.3.0"
       }

--- a/packages/branch-utilities/package.json
+++ b/packages/branch-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/branch-utilities",
-  "version": "5.0.0-pr58.1",
+  "version": "5.0.0-pr58.2",
   "description": "Utilities for local and ci to get branch name and stage",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/branch-utilities/package.json
+++ b/packages/branch-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/branch-utilities",
-  "version": "5.0.0-pr58.0",
+  "version": "5.0.0-pr58.1",
   "description": "Utilities for local and ci to get branch name and stage",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/branch-utilities/package.json
+++ b/packages/branch-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/branch-utilities",
-  "version": "4.0.0",
+  "version": "5.0.0-pr58.0",
   "description": "Utilities for local and ci to get branch name and stage",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/branch-utilities/package.json
+++ b/packages/branch-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/branch-utilities",
-  "version": "5.0.0-pr58.2",
+  "version": "5.0.0-pr58.3",
   "description": "Utilities for local and ci to get branch name and stage",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/branch-utilities/src/lib/base.utils.spec.ts
+++ b/packages/branch-utilities/src/lib/base.utils.spec.ts
@@ -81,11 +81,20 @@ describe('base utils', () => {
   })
 
   describe('parseBranchName', () => {
+
     test('works when valid pattern', () => {
-      expect(parseBranchName('#7-abc').branchId).toBe(7)
+      expect(parseBranchName('#7-abc')).toEqual({ branchId: 7, branchName: 'abc' } satisfies ReturnType<typeof parseBranchName>)
+
       expect(parseBranchName('#72-abc').branchId).toBe(72)
+      expect(parseBranchName('#000-int').branchId).toBe(0)
+      expect(parseBranchName('#001-test').branchId).toBe(1)
+
       expect(parseBranchName('#72- whatever').branchId).toBe(72)
       expect(parseBranchName('feature/#72-ok').branchId).toBe(72)
+    })
+
+    test('works for github copilot created branches', () => {
+      expect(parseBranchName('copilot/fix-123')).toEqual({ branchId: 123, branchName: 'fix' } satisfies ReturnType<typeof parseBranchName>)
     })
     test('throws when invalid pattern', () => {
       expect(() => parseBranchName('whrjwe')).toThrow()

--- a/packages/branch-utilities/src/lib/base.utils.spec.ts
+++ b/packages/branch-utilities/src/lib/base.utils.spec.ts
@@ -95,9 +95,13 @@ describe('base utils', () => {
 
     test('works for github copilot created branches', () => {
       expect(parseBranchName('copilot/fix-123')).toEqual({ branchId: 123, branchName: 'fix' } satisfies ReturnType<typeof parseBranchName>)
+      expect(parseBranchName('copilot/feat-123')).toEqual({ branchId: 123, branchName: 'feat' } satisfies ReturnType<typeof parseBranchName>)
     })
+
     test('throws when invalid pattern', () => {
       expect(() => parseBranchName('whrjwe')).toThrow()
+      expect(() => parseBranchName('copilot/123-fix')).toThrow()
+      expect(() => parseBranchName('feat/copilot/fix-123')).toThrow()
     })
   })
 })

--- a/packages/branch-utilities/src/lib/base.utils.ts
+++ b/packages/branch-utilities/src/lib/base.utils.ts
@@ -143,8 +143,8 @@ export function isMainBranch(branchName: string): boolean {
  * @throws Throws an error if given branchName does not match our convention
  */
 export function parseBranchName(branchName: string): { branchId: number; branchName: string } {
-  const matches = REGEX_BRANCH_NAME_DEFAULT.exec(branchName) || REGEX_BRANCH_NAME_COPILOT.exec(branchName)
-  if (matches && matches.groups) {
+  const matches = REGEX_BRANCH_NAME_DEFAULT.exec(branchName) ?? REGEX_BRANCH_NAME_COPILOT.exec(branchName)
+  if (matches?.groups) {
     return {
       branchId: parseInt(matches.groups['id'], 10),
       branchName: matches.groups['name'],
@@ -163,7 +163,7 @@ export function parseBranchName(branchName: string): { branchId: number; branchN
  * @return returns true if the stage is 'master' or 'main', false if not
  */
 export function isProduction(stageName: string): boolean {
-  return REGEX_MASTER.test(stageName) || REGEX_MAIN.test(stageName)
+  return REGEX_MASTER.test(stageName) ?? REGEX_MAIN.test(stageName)
 }
 
 /**

--- a/packages/branch-utilities/src/lib/base.utils.ts
+++ b/packages/branch-utilities/src/lib/base.utils.ts
@@ -18,7 +18,7 @@ const REGEX_BRANCH_NAME_DEFAULT = /^[a-z]*\/?#(?<id>\d+)-(?<name>.*)$/
  * regex to match the branch convention github copilot uses with the following named capture groups: id, name
  * @example copilot/fix-789 -> { id:  '789',  name: 'fix' }
  */
-const REGEX_BRANCH_NAME_COPILOT = /copilot\/(?<name>fix)-(?<id>\d+)/
+const REGEX_BRANCH_NAME_COPILOT = /^copilot\/(?<name>.*)-(?<id>\d+)$/
 
 export interface StageInfo {
   isProd: boolean

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/publish-helper",
-  "version": "4.0.1-pr58.0",
+  "version": "4.1.0-pr58.0",
   "description": "scripts for conventional (pre)releases",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@shiftcode/branch-utilities": "^5.0.0-pr58.0",
+    "@shiftcode/branch-utilities": "^5.0.0-pr58.1",
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/publish-helper",
-  "version": "4.1.0-pr58.1",
+  "version": "4.1.0-pr58.2",
   "description": "scripts for conventional (pre)releases",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@shiftcode/branch-utilities": "^5.0.0-pr58.2",
+    "@shiftcode/branch-utilities": "^5.0.0-pr58.3",
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/publish-helper",
-  "version": "4.0.0",
+  "version": "4.0.1-pr58.0",
   "description": "scripts for conventional (pre)releases",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@shiftcode/branch-utilities": "^4.0.0",
+    "@shiftcode/branch-utilities": "^5.0.0-pr58.0",
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -34,7 +34,7 @@
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {
-    "@shiftcode/branch-utilities": "^4.0.0 || ^4.0.0-pr45",
+    "@shiftcode/branch-utilities": "^4.0.0 || ^5.0.0-pr58.0",
     "lerna": "^8.1.6",
     "tslib": "^2.3.0"
   },

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -34,7 +34,7 @@
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {
-    "@shiftcode/branch-utilities": "^4.0.0 || ^5.0.0-pr58.0",
+    "@shiftcode/branch-utilities": "^4.0.0 || ^5.0.0-pr58 || ^5.0.0",
     "lerna": "^8.1.6",
     "tslib": "^2.3.0"
   },

--- a/packages/publish-helper/package.json
+++ b/packages/publish-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/publish-helper",
-  "version": "4.1.0-pr58.0",
+  "version": "4.1.0-pr58.1",
   "description": "scripts for conventional (pre)releases",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@shiftcode/branch-utilities": "^5.0.0-pr58.1",
+    "@shiftcode/branch-utilities": "^5.0.0-pr58.2",
     "@types/yargs": "^17.0.32"
   },
   "peerDependencies": {


### PR DESCRIPTION
…branch names

BREAKING CHANGE:
REGEX_BRANCH_NAME is no longer exported. use the utility function `parseBranchName` instead