### PR TITLE
Nest logger doesn’t log unhandled errors properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18773,7 +18773,7 @@
     },
     "packages/nest-logger": {
       "name": "@shiftcode/nest-logger",
-      "version": "1.0.1-pr79.1",
+      "version": "1.0.1-pr79.2",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18773,7 +18773,7 @@
     },
     "packages/nest-logger": {
       "name": "@shiftcode/nest-logger",
-      "version": "1.0.1-pr79.0",
+      "version": "1.0.1-pr79.1",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18773,7 +18773,7 @@
     },
     "packages/nest-logger": {
       "name": "@shiftcode/nest-logger",
-      "version": "1.0.0",
+      "version": "1.0.1-pr79.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.0.0",

--- a/packages/nest-logger/package.json
+++ b/packages/nest-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/nest-logger",
-  "version": "1.0.1-pr79.0",
+  "version": "1.0.1-pr79.1",
   "description": "NestJS support for the logger package",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/nest-logger/package.json
+++ b/packages/nest-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/nest-logger",
-  "version": "1.0.0",
+  "version": "1.0.1-pr79.0",
   "description": "NestJS support for the logger package",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/nest-logger/package.json
+++ b/packages/nest-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcode/nest-logger",
-  "version": "1.0.1-pr79.1",
+  "version": "1.0.1-pr79.2",
   "description": "NestJS support for the logger package",
   "repository": "https://github.com/shiftcode/sc-commons-public",
   "license": "MIT",

--- a/packages/nest-logger/src/model/nest-logger.spec.ts
+++ b/packages/nest-logger/src/model/nest-logger.spec.ts
@@ -1,0 +1,47 @@
+import { Logger, LogLevel } from '@shiftcode/logger'
+import { beforeEach, describe, expect, test } from 'vitest'
+
+import { MockLogTransport } from '../../test/mock-log.transport.js'
+import { NestLogger } from './nest-logger.js'
+
+describe('NestLogger', () => {
+  let transport: MockLogTransport
+  let logger: Logger
+  let nestLogger: NestLogger
+
+  beforeEach(() => {
+    transport = new MockLogTransport({ logLevel: LogLevel.DEBUG, mockAttribute: 'test' })
+    logger = new Logger('TestLogger', '#ffffff', [transport])
+    nestLogger = new NestLogger(logger)
+  })
+
+  test('error(message, trace, context) forwards args as flat array, not nested', () => {
+    nestLogger.error('msg', 'trace', 'ctx')
+    expect(transport.logArgs?.args).toEqual(['msg', 'trace', 'ctx'])
+  })
+
+  test('warn(message, context) forwards args as flat array', () => {
+    nestLogger.warn('msg', 'ctx')
+    expect(transport.logArgs?.args).toEqual(['msg', 'ctx'])
+  })
+
+  test('log(message, context) forwards args as flat array', () => {
+    nestLogger.log('msg', 'ctx')
+    expect(transport.logArgs?.args).toEqual(['msg', 'ctx'])
+  })
+
+  test('debug(message, context) forwards args as flat array', () => {
+    nestLogger.debug('msg', 'ctx')
+    expect(transport.logArgs?.args).toEqual(['msg', 'ctx'])
+  })
+
+  test('verbose(message, context) forwards args as flat array', () => {
+    nestLogger.verbose('msg', 'ctx')
+    expect(transport.logArgs?.args).toEqual(['msg', 'ctx'])
+  })
+
+  test('error with only a message forwards a single-element args array', () => {
+    nestLogger.error('only message')
+    expect(transport.logArgs?.args).toEqual(['only message'])
+  })
+})

--- a/packages/nest-logger/src/model/nest-logger.ts
+++ b/packages/nest-logger/src/model/nest-logger.ts
@@ -9,22 +9,22 @@ export class NestLogger implements LoggerService {
   constructor(private readonly logger: Logger) {}
 
   error(message: any, ...optionalParams: any[]) {
-    this.logger.error(message, optionalParams)
+    this.logger.error(message, ...optionalParams)
   }
 
   warn(message: any, ...optionalParams: any[]) {
-    this.logger.warn(message, optionalParams)
+    this.logger.warn(message, ...optionalParams)
   }
 
   debug(message: any, ...optionalParams: any[]) {
-    this.logger.debug(message, optionalParams)
+    this.logger.debug(message, ...optionalParams)
   }
 
   verbose(message: any, ...optionalParams: any[]) {
-    this.debug(message, optionalParams)
+    this.debug(message, ...optionalParams)
   }
 
   log(message: any, ...optionalParams: any[]) {
-    this.logger.info(message, optionalParams)
+    this.logger.info(message, ...optionalParams)
   }
 }

--- a/packages/nest-logger/src/model/nest-logger.ts
+++ b/packages/nest-logger/src/model/nest-logger.ts
@@ -8,23 +8,23 @@ import { Logger } from '@shiftcode/logger'
 export class NestLogger implements LoggerService {
   constructor(private readonly logger: Logger) {}
 
-  error(message: any, trace?: string) {
-    this.logger.error([message, trace])
+  error(message: any, ...optionalParams: any[]) {
+    this.logger.error(message, optionalParams)
   }
 
-  warn(message: any) {
-    this.logger.warn([message])
+  warn(message: any, ...optionalParams: any[]) {
+    this.logger.warn(message, optionalParams)
   }
 
-  debug(message: any) {
-    this.logger.debug([message])
+  debug(message: any, ...optionalParams: any[]) {
+    this.logger.debug(message, optionalParams)
   }
 
-  verbose(message: any) {
-    this.debug(message)
+  verbose(message: any, ...optionalParams: any[]) {
+    this.debug(message, optionalParams)
   }
 
-  log(message: any) {
-    this.logger.info([message])
+  log(message: any, ...optionalParams: any[]) {
+    this.logger.info(message, optionalParams)
   }
 }

--- a/packages/nest-logger/test/mock-log.transport.ts
+++ b/packages/nest-logger/test/mock-log.transport.ts
@@ -5,8 +5,16 @@ export interface MockLogTransportConfig {
   mockAttribute: string
 }
 
+export interface MockLogArgs {
+  level: LogLevel
+  clazzName: string
+  hexColor: string
+  timestamp: Date
+  args: unknown[]
+}
+
 export class MockLogTransport extends LogTransport {
-  logArgs: any
+  logArgs: MockLogArgs | undefined
 
   constructor(config: MockLogTransportConfig) {
     super(config.logLevel)


### PR DESCRIPTION
The `NestLogger` wrapper incorrectly passed its arguments as an array, which was subsequently not serialised correctly